### PR TITLE
Wrong file name in readme me

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 
 ## Usage
 
-Make yourself a `config/cloudwatch_scheduler.rb` file:
+Make yourself a `config/cloudwatch_schedule.rb` file:
 
 ```ruby
 require "cloudwatch_scheduler"

--- a/lib/cloudwatch_scheduler/job.rb
+++ b/lib/cloudwatch_scheduler/job.rb
@@ -1,6 +1,7 @@
 module CloudwatchScheduler
   class Job < ::ApplicationJob
-    queue_as :cloudwatch_scheduler
+    # :ProductionQueue or :BetaQueue
+    queue_as "#{Rails.env.titlecase}ScheduledJobs".to_sym
 
     def initialize(config: CloudwatchScheduler.global)
       @config = config

--- a/lib/cloudwatch_scheduler/job.rb
+++ b/lib/cloudwatch_scheduler/job.rb
@@ -1,6 +1,6 @@
 module CloudwatchScheduler
   class Job < ::ApplicationJob
-    # :ProductionQueue or :BetaQueue
+    # :ProductionScheduledJobs or :BetaScheduledJobs
     queue_as "#{Rails.env.titlecase}ScheduledJobs".to_sym
 
     def initialize(config: CloudwatchScheduler.global)


### PR DESCRIPTION
Stumped me for a few minutes. The config file you're expecting is `config/cloudwatch_schedule.rb` but the README says `config/cloudwatch_scheduler.rb`