### PR TITLE
CI: Update patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.5.3
-  - 2.6.1
-before_install: gem install bundler
+  - 2.5.5
+  - 2.6.3
 gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile


### PR DESCRIPTION
This PR updates the Ruby versions used in the CI matrix.

Also:

  - drop unused Travis directive sudo: false - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration