### PR TITLE
Ruby 3 and Rails 7 compatibility

### DIFF
--- a/cloudwatch_scheduler.gemspec
+++ b/cloudwatch_scheduler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r(^exe/)) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.6"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "aws-sdk-cloudwatchevents", "~> 1.13"
   spec.add_dependency "aws-sdk-sqs",              "~> 1.10"

--- a/lib/cloudwatch_scheduler/engine.rb
+++ b/lib/cloudwatch_scheduler/engine.rb
@@ -3,20 +3,22 @@
 module CloudwatchScheduler
   class Engine < Rails::Engine
     initializer "cloudwatch_scheduler.setup_job" do
-      # Have to do this in initializer rather than require time because it
-      # inherits from ApplicationJob
-      require "cloudwatch_scheduler/job"
+      config.to_prepare do
+        # Have to do this in initializer rather than require time because it
+        # inherits from ApplicationJob
+        require "cloudwatch_scheduler/job"
 
-      # Explicitly register this worker, because Shoryuken expects the message
-      # attributes to specify the job class, and these jobs are produced by
-      # Cloudwatch Events, which provide no way to set message attributes
-      Shoryuken.worker_registry.register_worker(
-        CloudwatchScheduler::Job.queue_name,
-        ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
-      )
+        # Explicitly register this worker, because Shoryuken expects the message
+        # attributes to specify the job class, and these jobs are produced by
+        # Cloudwatch Events, which provide no way to set message attributes
+        Shoryuken.worker_registry.register_worker(
+          CloudwatchScheduler::Job.queue_name,
+          ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
+        )
 
-      # Load the configuration
-      require Rails.root.join("config/cloudwatch_schedule").to_s
+        # Load the configuration
+        require Rails.root.join("config/cloudwatch_schedule").to_s
+      end
     end
 
     rake_tasks do

--- a/lib/cloudwatch_scheduler/provisioner.rb
+++ b/lib/cloudwatch_scheduler/provisioner.rb
@@ -81,7 +81,7 @@ module CloudwatchScheduler
     private
 
     def create_dead_letter_queue!
-      dlq_name = queue_name + "-failures"
+      dlq_name = "#{queue_name}-failures"
       dlq_url = sqs.create_queue(queue_name: dlq_name).queue_url
       dlq_arn = sqs.get_queue_attributes(queue_url: dlq_url, attribute_names: ["QueueArn"]).attributes["QueueArn"]
 

--- a/lib/cloudwatch_scheduler/provisioner.rb
+++ b/lib/cloudwatch_scheduler/provisioner.rb
@@ -96,7 +96,7 @@ module CloudwatchScheduler
     end
 
     def queue_name
-      config.queue_name
+      config.actual_queue_name
     end
 
     def queue_url


### PR DESCRIPTION
I tried installing this on a Rails 7 app using Ruby 3 and ran into only a few issues.  I've fixed them in this PR:

* The gemspec was using a pessimistic version constraint that didn't allow Ruby 3
* Rails 7 changed how autoloading works, so now initializers need to reference reloadable constants in a `to_prepare` block (see https://rubyonrails.org/2021/9/3/autoloading-in-rails-7-get-ready)
* If the config defaults were left in place, `queue_name` was a symbol, which can't be `+`ed with a string (not sure if this was always the case or if it's a Ruby 3 change)

I was a bit worried that I'd break earlier versions of Rails with the `to_prepare` change, but it seems as if this method has been in place since Rails 3, so it seems safe to do.  (I have not actually tested this on Rails 5 or 6, but could if you don't have an easy way to do that.)